### PR TITLE
Add securitygroup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Usage:
 
 Available Commands:
   backup
-  completion    Generate the autocompletion script for the specified shell
-  help          Help about any command
-  image         Clone an image
-  secret        Clone a secret
+  completion     Generate the autocompletion script for the specified shell
+  help           Help about any command
+  image          Clone an image
+  secret         Clone a secret
   security-group Clone a security group
-  server        Clone a server
-  share         Clone a share
-  version       Print version information
-  volume        Clone a volume
+  server         Clone a server
+  share          Clone a share
+  version        Print version information
+  volume         Clone a volume
 
 Flags:
   -d, --debug                                     print out request and response objects
@@ -54,6 +54,7 @@ Flags:
       --timeout-backup string                     timeout to wait for a backup status (default "24h")
       --timeout-image string                      timeout to wait for an image status (default "24h")
       --timeout-secret string                     timeout to wait for a secret status (default "24h")
+      --timeout-security-group string             timeout to wait for a security group status (default "24h")
       --timeout-server string                     timeout to wait for a server status (default "24h")
       --timeout-share string                      timeout to wait for a share status (default "24h")
       --timeout-share-replica string              timeout to wait for a share replica status (default "24h")

--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ Usage:
   cyclone [command]
 
 Available Commands:
-  backup      
-  completion  Generate the autocompletion script for the specified shell
-  help        Help about any command
-  image       Clone an image
-  secret      Clone a secret
-  server      Clone a server
-  share       Clone a share
-  version     Print version information
-  volume      Clone a volume
+  backup
+  completion    Generate the autocompletion script for the specified shell
+  help          Help about any command
+  image         Clone an image
+  secret        Clone a secret
+  securitygroup Clone a securitygroup
+  server        Clone a server
+  share         Clone a share
+  version       Print version information
+  volume        Clone a volume
 
 Flags:
   -d, --debug                                     print out request and response objects

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Available Commands:
   help          Help about any command
   image         Clone an image
   secret        Clone a secret
-  securitygroup Clone a securitygroup
+  security-group Clone a security group
   server        Clone a server
   share         Clone a share
   version       Print version information

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -106,6 +106,7 @@ func initRootCmdFlags() {
 	RootCmd.PersistentFlags().StringP("timeout-share-snapshot", "", "24h", "timeout to wait for a share snapshot status")
 	RootCmd.PersistentFlags().StringP("timeout-share-replica", "", "24h", "timeout to wait for a share replica status")
 	RootCmd.PersistentFlags().StringP("timeout-secret", "", "24h", "timeout to wait for a secret status")
+	RootCmd.PersistentFlags().StringP("timeout-security-group", "", "24h", "timeout to wait for a security group status")
 	RootCmd.PersistentFlags().BoolP("image-web-download", "", false, "use Glance web-download image import method")
 	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("yes", RootCmd.PersistentFlags().Lookup("yes"))
@@ -128,6 +129,7 @@ func initRootCmdFlags() {
 	viper.BindPFlag("timeout-share-snapshot", RootCmd.PersistentFlags().Lookup("timeout-share-snapshot"))
 	viper.BindPFlag("timeout-share-replica", RootCmd.PersistentFlags().Lookup("timeout-share-replica"))
 	viper.BindPFlag("timeout-secret", RootCmd.PersistentFlags().Lookup("timeout-secret"))
+	viper.BindPFlag("timeout-security-group", RootCmd.PersistentFlags().Lookup("timeout-security-group"))
 	viper.BindPFlag("image-web-download", RootCmd.PersistentFlags().Lookup("image-web-download"))
 }
 
@@ -164,6 +166,7 @@ func parseTimeoutArgs() error {
 	parseTimeoutArg("timeout-share-snapshot", &waitForShareSnapshotSec, &errors)
 	parseTimeoutArg("timeout-share-replica", &waitForShareReplicaSec, &errors)
 	parseTimeoutArg("timeout-secret", &waitForSecretSec, &errors)
+	parseTimeoutArg("timeout-security-group", &waitForSecurityGroupSec, &errors)
 	if len(errors) > 0 {
 		return fmt.Errorf("%q", errors)
 	}

--- a/pkg/security_group.go
+++ b/pkg/security_group.go
@@ -1,0 +1,212 @@
+package pkg
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	waitForSecurityGroupSec    float64
+	syncedSrcDstSecurityGroups = make(map[string]string)
+	disableDetection           bool
+)
+
+func securityGroupsIDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	pages, err := groups.List(client, groups.ListOpts{
+		Name: name,
+	}).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := groups.ExtractGroups(pages)
+	if err != nil {
+		return "", err
+	}
+
+	ids := make([]string, len(all))
+	for i := range all {
+		ids[i] = all[i].ID
+	}
+
+	switch count := len(ids); count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "security-group"}
+	case 1:
+		return ids[0], nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "security-group"}
+	}
+}
+
+func retryRulesCreate(client *gophercloud.ServiceClient, opts rules.CreateOpts) (*rules.SecGroupRule, error) {
+	var rule *rules.SecGroupRule
+	var err error
+	err = NewBackoff(int(waitForSecurityGroupSec), backoffFactor, backoffMaxInterval).WaitFor(func() (bool, error) {
+		rule, err = rules.Create(client, opts).Extract()
+		var errDefault429 gophercloud.ErrDefault429
+		if errors.As(err, &errDefault429) {
+			// 429 is a rate limit error, we should retry
+			return false, nil
+		}
+		return true, err
+	})
+	return rule, err
+}
+
+// SecurityGroupCmd represents the security group command
+var SecurityGroupCmd = &cobra.Command{
+	Use:   "security-group <name|id>",
+	Args:  cobra.ExactArgs(1),
+	Short: "Clone a security group",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := parseTimeoutArgs(); err != nil {
+			return err
+		}
+		return viper.BindPFlags(cmd.Flags())
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// migrate security group
+		securityGroup := args[0]
+		toName, _ := cmd.Flags().GetString("to-security-group-name")
+		disableDetection, _ = cmd.Flags().GetBool("disable-target-security-group-detection")
+
+		// source and destination parameters
+		loc, err := getSrcAndDst("")
+		if err != nil {
+			return err
+		}
+
+		srcProvider, err := newOpenStackClient(loc.Src)
+		if err != nil {
+			return fmt.Errorf("failed to create a source OpenStack client: %v", err)
+		}
+
+		srcNetworkClient, err := newNetworkV2Client(srcProvider, loc.Src.Region)
+		if err != nil {
+			return fmt.Errorf("failed to create source network client: %v", err)
+		}
+
+		// resolve security group name to an ID
+		if v, err := securityGroupsIDFromName(srcNetworkClient, securityGroup); err == nil {
+			securityGroup = v
+		} else if err, ok := err.(gophercloud.ErrMultipleResourcesFound); ok {
+			return err
+		}
+
+		dstProvider, err := newOpenStackClient(loc.Dst)
+		if err != nil {
+			return fmt.Errorf("failed to create a destination OpenStack client: %v", err)
+		}
+
+		dstNetworkClient, err := newNetworkV2Client(dstProvider, loc.Dst.Region)
+		if err != nil {
+			return fmt.Errorf("failed to create destination network client: %v", err)
+		}
+
+		defer measureTime()
+
+		dstSecurityGroup, err := migrateSecurityGroup(srcNetworkClient, dstNetworkClient, securityGroup, toName)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("Target security group name is %q (id: %q)", dstSecurityGroup.Name, dstSecurityGroup.ID)
+
+		return nil
+	},
+}
+
+func migrateSecurityGroup(srcNetworkClient *gophercloud.ServiceClient, dstNetworkClient *gophercloud.ServiceClient, securityGroup string, toSecurityGroupName string) (*groups.SecGroup, error) {
+	sg, err := groups.Get(srcNetworkClient, securityGroup).Extract()
+	if err != nil {
+		return nil, err
+	}
+
+	if toSecurityGroupName == "" {
+		toSecurityGroupName = sg.Name
+	}
+	if !disableDetection {
+		// check if security group with the same name already exists in the destination
+		if secGroupID, err := securityGroupsIDFromName(dstNetworkClient, toSecurityGroupName); err == nil {
+			// security group already exists
+			return groups.Get(dstNetworkClient, secGroupID).Extract()
+		}
+	}
+
+	log.Printf("Creating security group %q", toSecurityGroupName)
+	createOpts := groups.CreateOpts{
+		Name:        toSecurityGroupName,
+		Description: sg.Description,
+	}
+	newSecurityGroup, err := groups.Create(dstNetworkClient, createOpts).Extract()
+	if err != nil {
+		return nil, err
+	}
+	// store mapping of source and destination security group IDs in case we encounter a rule with a remote group
+	syncedSrcDstSecurityGroups[securityGroup] = newSecurityGroup.ID
+
+	// delete default egress rules to get a clean slate
+	for _, rule := range newSecurityGroup.Rules {
+		if rule.Direction == "egress" {
+			if err = rules.Delete(dstNetworkClient, rule.ID).ExtractErr(); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	for _, rule := range sg.Rules {
+		var remoteGroupID string
+		if rule.RemoteGroupID != "" {
+			if rule.RemoteGroupID == rule.ID {
+				remoteGroupID = newSecurityGroup.ID
+			} else if targetRemoteID, ok := syncedSrcDstSecurityGroups[rule.RemoteGroupID]; ok {
+				// remote group already exists
+				remoteGroupID = targetRemoteID
+			} else {
+				// create remote security group if it doesn't exist
+				remoteSecurityGroup, err := migrateSecurityGroup(srcNetworkClient, dstNetworkClient, rule.RemoteGroupID, "")
+				if err != nil {
+					return nil, err
+				}
+				// update rule with new remote group ID
+				remoteGroupID = remoteSecurityGroup.ID
+			}
+		}
+
+		ruleCreateOpts := rules.CreateOpts{
+			Direction:      rules.RuleDirection(rule.Direction),
+			Description:    rule.Description,
+			EtherType:      rules.RuleEtherType(rule.EtherType),
+			SecGroupID:     newSecurityGroup.ID,
+			PortRangeMax:   rule.PortRangeMax,
+			PortRangeMin:   rule.PortRangeMin,
+			Protocol:       rules.RuleProtocol(rule.Protocol),
+			RemoteGroupID:  remoteGroupID,
+			RemoteIPPrefix: rule.RemoteIPPrefix,
+		}
+
+		// retry rule creation on 429 rate limit errors
+		if _, err = retryRulesCreate(dstNetworkClient, ruleCreateOpts); err != nil {
+			return nil, err
+		}
+	}
+
+	return newSecurityGroup, nil
+}
+
+func init() {
+	initSecurityGroupCmdFlags()
+	RootCmd.AddCommand(SecurityGroupCmd)
+}
+
+func initSecurityGroupCmdFlags() {
+	SecurityGroupCmd.Flags().StringP("to-security-group-name", "", "", "destination security group name")
+	SecurityGroupCmd.Flags().BoolP("disable-target-security-group-detection", "", false, "disable automatic detection of existent target security groups")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/doc.go
@@ -1,0 +1,58 @@
+/*
+Package groups provides information and interaction with Security Groups
+for the OpenStack Networking service.
+
+Example to List Security Groups
+
+	listOpts := groups.ListOpts{
+		TenantID: "966b3c7d36a24facaf20b7e458bf2192",
+	}
+
+	allPages, err := groups.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allGroups, err := groups.ExtractGroups(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, group := range allGroups {
+		fmt.Printf("%+v\n", group)
+	}
+
+Example to Create a Security Group
+
+	createOpts := groups.CreateOpts{
+		Name:        "group_name",
+		Description: "A Security Group",
+	}
+
+	group, err := groups.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+
+	updateOpts := groups.UpdateOpts{
+		Name: "new_name",
+	}
+
+	group, err := groups.Update(networkClient, groupID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group
+
+	groupID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := groups.Delete(networkClient, groupID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package groups

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/requests.go
@@ -1,0 +1,133 @@
+package groups
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the group attributes you want to see returned. SortKey allows you to
+// sort by a particular network attribute. SortDir sets the direction, and is
+// either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	ID          string `q:"id"`
+	Name        string `q:"name"`
+	Description string `q:"description"`
+	TenantID    string `q:"tenant_id"`
+	ProjectID   string `q:"project_id"`
+	Limit       int    `q:"limit"`
+	Marker      string `q:"marker"`
+	SortKey     string `q:"sort_key"`
+	SortDir     string `q:"sort_dir"`
+	Tags        string `q:"tags"`
+	TagsAny     string `q:"tags-any"`
+	NotTags     string `q:"not-tags"`
+	NotTagsAny  string `q:"not-tags-any"`
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// security groups. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u := rootURL(c) + q.String()
+	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return SecGroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSecGroupCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new security group.
+type CreateOpts struct {
+	// Human-readable name for the Security Group. Does not have to be unique.
+	Name string `json:"name" required:"true"`
+
+	// TenantID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// ProjectID is the UUID of the project who owns the Group.
+	// Only administrative users can specify a tenant UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// Describes the security group.
+	Description string `json:"description,omitempty"`
+}
+
+// ToSecGroupCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSecGroupCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group")
+}
+
+// Create is an operation which provisions a new security group with default
+// security group rules for the IPv4 and IPv6 ether types.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSecGroupCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToSecGroupUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update an existing security
+// group.
+type UpdateOpts struct {
+	// Human-readable name for the Security Group. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Describes the security group.
+	Description *string `json:"description,omitempty"`
+}
+
+// ToSecGroupUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToSecGroupUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group")
+}
+
+// Update is an operation which updates an existing security group.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToSecGroupUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	resp, err := c.Put(resourceURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves a particular security group based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will permanently delete a particular security group based on its
+// unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(resourceURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/results.go
@@ -1,0 +1,158 @@
+package groups
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SecGroup represents a container for security group rules.
+type SecGroup struct {
+	// The UUID for the security group.
+	ID string
+
+	// Human-readable name for the security group. Might not be unique.
+	// Cannot be named "default" as that is automatically created for a tenant.
+	Name string
+
+	// The security group description.
+	Description string
+
+	// A slice of security group rules that dictate the permitted behaviour for
+	// traffic entering and leaving the group.
+	Rules []rules.SecGroupRule `json:"security_group_rules"`
+
+	// TenantID is the project owner of the security group.
+	TenantID string `json:"tenant_id"`
+
+	// UpdatedAt and CreatedAt contain ISO-8601 timestamps of when the state of the
+	// security group last changed, and when it was created.
+	UpdatedAt time.Time `json:"-"`
+	CreatedAt time.Time `json:"-"`
+
+	// ProjectID is the project owner of the security group.
+	ProjectID string `json:"project_id"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+}
+
+func (r *SecGroup) UnmarshalJSON(b []byte) error {
+	type tmp SecGroup
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = SecGroup(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = SecGroup(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
+}
+
+// SecGroupPage is the page returned by a pager when traversing over a
+// collection of security groups.
+type SecGroupPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of security groups has
+// reached the end of a page and the pager seeks to traverse over a new one. In
+// order to do this, it needs to construct the next page's URL.
+func (r SecGroupPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"security_groups_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SecGroupPage struct is empty.
+func (r SecGroupPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	is, err := ExtractGroups(r)
+	return len(is) == 0, err
+}
+
+// ExtractGroups accepts a Page struct, specifically a SecGroupPage struct,
+// and extracts the elements into a slice of SecGroup structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractGroups(r pagination.Page) ([]SecGroup, error) {
+	var s struct {
+		SecGroups []SecGroup `json:"security_groups"`
+	}
+	err := (r.(SecGroupPage)).ExtractInto(&s)
+	return s.SecGroups, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a security group.
+func (r commonResult) Extract() (*SecGroup, error) {
+	var s struct {
+		SecGroup *SecGroup `json:"security_group"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SecGroup, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroup.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a SecGroup.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroup.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups/urls.go
@@ -1,0 +1,13 @@
+package groups
+
+import "github.com/gophercloud/gophercloud"
+
+const rootPath = "security-groups"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/doc.go
@@ -1,0 +1,50 @@
+/*
+Package rules provides information and interaction with Security Group Rules
+for the OpenStack Networking service.
+
+Example to List Security Groups Rules
+
+	listOpts := rules.ListOpts{
+		Protocol: "tcp",
+	}
+
+	allPages, err := rules.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allRules, err := rules.ExtractRules(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, rule := range allRules {
+		fmt.Printf("%+v\n", rule)
+	}
+
+Example to Create a Security Group Rule
+
+	createOpts := rules.CreateOpts{
+		Direction:     "ingress",
+		PortRangeMin:  80,
+		EtherType:     rules.EtherType4,
+		PortRangeMax:  80,
+		Protocol:      "tcp",
+		RemoteGroupID: "85cc3048-abc3-43cc-89b3-377341426ac5",
+		SecGroupID:    "a7734e61-b545-452d-a3cd-0189cbd9747a",
+	}
+
+	rule, err := rules.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Security Group Rule
+
+	ruleID := "37d94f8a-d136-465c-ae46-144f0d8ef141"
+	err := rules.Delete(networkClient, ruleID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package rules

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/requests.go
@@ -1,0 +1,164 @@
+package rules
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the security group rule attributes you want to see returned. SortKey allows
+// you to sort by a particular network attribute. SortDir sets the direction,
+// and is either `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Direction      string `q:"direction"`
+	EtherType      string `q:"ethertype"`
+	ID             string `q:"id"`
+	Description    string `q:"description"`
+	PortRangeMax   int    `q:"port_range_max"`
+	PortRangeMin   int    `q:"port_range_min"`
+	Protocol       string `q:"protocol"`
+	RemoteGroupID  string `q:"remote_group_id"`
+	RemoteIPPrefix string `q:"remote_ip_prefix"`
+	SecGroupID     string `q:"security_group_id"`
+	TenantID       string `q:"tenant_id"`
+	ProjectID      string `q:"project_id"`
+	Limit          int    `q:"limit"`
+	Marker         string `q:"marker"`
+	SortKey        string `q:"sort_key"`
+	SortDir        string `q:"sort_dir"`
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// security group rules. It accepts a ListOpts struct, which allows you to filter
+// and sort the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOpts) pagination.Pager {
+	q, err := gophercloud.BuildQueryString(&opts)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+	u := rootURL(c) + q.String()
+	return pagination.NewPager(c, u, func(r pagination.PageResult) pagination.Page {
+		return SecGroupRulePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type RuleDirection string
+type RuleProtocol string
+type RuleEtherType string
+
+// Constants useful for CreateOpts
+const (
+	DirIngress        RuleDirection = "ingress"
+	DirEgress         RuleDirection = "egress"
+	EtherType4        RuleEtherType = "IPv4"
+	EtherType6        RuleEtherType = "IPv6"
+	ProtocolAH        RuleProtocol  = "ah"
+	ProtocolDCCP      RuleProtocol  = "dccp"
+	ProtocolEGP       RuleProtocol  = "egp"
+	ProtocolESP       RuleProtocol  = "esp"
+	ProtocolGRE       RuleProtocol  = "gre"
+	ProtocolICMP      RuleProtocol  = "icmp"
+	ProtocolIGMP      RuleProtocol  = "igmp"
+	ProtocolIPIP      RuleProtocol  = "ipip"
+	ProtocolIPv6Encap RuleProtocol  = "ipv6-encap"
+	ProtocolIPv6Frag  RuleProtocol  = "ipv6-frag"
+	ProtocolIPv6ICMP  RuleProtocol  = "ipv6-icmp"
+	ProtocolIPv6NoNxt RuleProtocol  = "ipv6-nonxt"
+	ProtocolIPv6Opts  RuleProtocol  = "ipv6-opts"
+	ProtocolIPv6Route RuleProtocol  = "ipv6-route"
+	ProtocolOSPF      RuleProtocol  = "ospf"
+	ProtocolPGM       RuleProtocol  = "pgm"
+	ProtocolRSVP      RuleProtocol  = "rsvp"
+	ProtocolSCTP      RuleProtocol  = "sctp"
+	ProtocolTCP       RuleProtocol  = "tcp"
+	ProtocolUDP       RuleProtocol  = "udp"
+	ProtocolUDPLite   RuleProtocol  = "udplite"
+	ProtocolVRRP      RuleProtocol  = "vrrp"
+	ProtocolAny       RuleProtocol  = "any"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToSecGroupRuleCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new security group
+// rule.
+type CreateOpts struct {
+	// Must be either "ingress" or "egress": the direction in which the security
+	// group rule is applied.
+	Direction RuleDirection `json:"direction" required:"true"`
+
+	// String description of each rule, optional
+	Description string `json:"description,omitempty"`
+
+	// Must be "IPv4" or "IPv6", and addresses represented in CIDR must match the
+	// ingress or egress rules.
+	EtherType RuleEtherType `json:"ethertype" required:"true"`
+
+	// The security group ID to associate with this security group rule.
+	SecGroupID string `json:"security_group_id" required:"true"`
+
+	// The maximum port number in the range that is matched by the security group
+	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
+	// the protocol is ICMP, this value must be an ICMP type.
+	PortRangeMax int `json:"port_range_max,omitempty"`
+
+	// The minimum port number in the range that is matched by the security group
+	// rule. If the protocol is TCP or UDP, this value must be less than or equal
+	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
+	// value must be an ICMP type.
+	PortRangeMin int `json:"port_range_min,omitempty"`
+
+	// The protocol that is matched by the security group rule. Valid values are
+	// "tcp", "udp", "icmp" or an empty string.
+	Protocol RuleProtocol `json:"protocol,omitempty"`
+
+	// The remote group ID to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix.
+	RemoteGroupID string `json:"remote_group_id,omitempty"`
+
+	// The remote IP prefix to be associated with this security group rule. You can
+	// specify either RemoteGroupID or RemoteIPPrefix. This attribute matches the
+	// specified IP prefix as the source IP address of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix,omitempty"`
+
+	// TenantID is the UUID of the project who owns the Rule.
+	// Only administrative users can specify a project UUID other than their own.
+	ProjectID string `json:"project_id,omitempty"`
+}
+
+// ToSecGroupRuleCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToSecGroupRuleCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "security_group_rule")
+}
+
+// Create is an operation which adds a new security group rule and associates it
+// with an existing security group (whose ID is specified in CreateOpts).
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToSecGroupRuleCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(rootURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves a particular security group rule based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(resourceURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will permanently delete a particular security group rule based on its
+// unique ID.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(resourceURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/results.go
@@ -1,0 +1,131 @@
+package rules
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// SecGroupRule represents a rule to dictate the behaviour of incoming or
+// outgoing traffic for a particular security group.
+type SecGroupRule struct {
+	// The UUID for this security group rule.
+	ID string
+
+	// The direction in which the security group rule is applied. The only values
+	// allowed are "ingress" or "egress". For a compute instance, an ingress
+	// security group rule is applied to incoming (ingress) traffic for that
+	// instance. An egress rule is applied to traffic leaving the instance.
+	Direction string
+
+	// Description of the rule
+	Description string `json:"description"`
+
+	// Must be IPv4 or IPv6, and addresses represented in CIDR must match the
+	// ingress or egress rules.
+	EtherType string `json:"ethertype"`
+
+	// The security group ID to associate with this security group rule.
+	SecGroupID string `json:"security_group_id"`
+
+	// The minimum port number in the range that is matched by the security group
+	// rule. If the protocol is TCP or UDP, this value must be less than or equal
+	// to the value of the PortRangeMax attribute. If the protocol is ICMP, this
+	// value must be an ICMP type.
+	PortRangeMin int `json:"port_range_min"`
+
+	// The maximum port number in the range that is matched by the security group
+	// rule. The PortRangeMin attribute constrains the PortRangeMax attribute. If
+	// the protocol is ICMP, this value must be an ICMP type.
+	PortRangeMax int `json:"port_range_max"`
+
+	// The protocol that is matched by the security group rule. Valid values are
+	// "tcp", "udp", "icmp" or an empty string.
+	Protocol string
+
+	// The remote group ID to be associated with this security group rule. You
+	// can specify either RemoteGroupID or RemoteIPPrefix.
+	RemoteGroupID string `json:"remote_group_id"`
+
+	// The remote IP prefix to be associated with this security group rule. You
+	// can specify either RemoteGroupID or RemoteIPPrefix . This attribute
+	// matches the specified IP prefix as the source IP address of the IP packet.
+	RemoteIPPrefix string `json:"remote_ip_prefix"`
+
+	// TenantID is the project owner of this security group rule.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of this security group rule.
+	ProjectID string `json:"project_id"`
+}
+
+// SecGroupRulePage is the page returned by a pager when traversing over a
+// collection of security group rules.
+type SecGroupRulePage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of security group rules has
+// reached the end of a page and the pager seeks to traverse over a new one. In
+// order to do this, it needs to construct the next page's URL.
+func (r SecGroupRulePage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"security_group_rules_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a SecGroupRulePage struct is empty.
+func (r SecGroupRulePage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	is, err := ExtractRules(r)
+	return len(is) == 0, err
+}
+
+// ExtractRules accepts a Page struct, specifically a SecGroupRulePage struct,
+// and extracts the elements into a slice of SecGroupRule structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractRules(r pagination.Page) ([]SecGroupRule, error) {
+	var s struct {
+		SecGroupRules []SecGroupRule `json:"security_group_rules"`
+	}
+	err := (r.(SecGroupRulePage)).ExtractInto(&s)
+	return s.SecGroupRules, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a security rule.
+func (r commonResult) Extract() (*SecGroupRule, error) {
+	var s struct {
+		SecGroupRule *SecGroupRule `json:"security_group_rule"`
+	}
+	err := r.ExtractInto(&s)
+	return s.SecGroupRule, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a SecGroupRule.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a SecGroupRule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules/urls.go
@@ -1,0 +1,13 @@
+package rules
+
+import "github.com/gophercloud/gophercloud"
+
+const rootPath = "security-group-rules"
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,6 +47,8 @@ github.com/gophercloud/gophercloud/openstack/imageservice/v2/tasks
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/acls
 github.com/gophercloud/gophercloud/openstack/keymanager/v1/secrets
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
+github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/networks
 github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/networking/v2/subnets


### PR DESCRIPTION
This PR adds the entity securitygroup to cyclone and supports the one-way syncing of security groups and all related remote security groups.
